### PR TITLE
Abstract main thread JS operations using InstructionList data structure

### DIFF
--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
@@ -421,10 +421,6 @@ export abstract class OpcodeBuilder<Locator> extends SimpleOpcodeBuilder {
     this.push(Op.OpenElement, this.constants.string(tag));
   }
 
-  openElementWithOperations(tag: string) {
-    this.push(Op.OpenElementWithOperations, this.constants.string(tag));
-  }
-
   openDynamicElement() {
     this.push(Op.OpenDynamicElement);
   }

--- a/packages/@glimmer/opcode-compiler/lib/syntax.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax.ts
@@ -94,7 +94,7 @@ export function statementCompiler() {
   STATEMENTS.add(Ops.OpenSplattedElement, (sexp: S.SplatElement, builder) => {
     builder.setComponentAttrs(true);
     builder.putComponentOperations();
-    builder.openElementWithOperations(sexp[1]);
+    builder.openPrimitiveElement(sexp[1]);
   });
 
   STATEMENTS.add(Ops.Component, (sexp: S.Component, builder) => {
@@ -225,7 +225,7 @@ export function statementCompiler() {
 
   CLIENT_SIDE.add(ClientSide.Ops.OpenComponentElement, (sexp: ClientSide.OpenComponentElement, builder) => {
     builder.putComponentOperations();
-    builder.openElementWithOperations(sexp[2]);
+    builder.openPrimitiveElement(sexp[2]);
   });
 
   CLIENT_SIDE.add(ClientSide.Ops.DidCreateElement, (_sexp: ClientSide.DidCreateElement, builder) => {

--- a/packages/@glimmer/runtime/index.ts
+++ b/packages/@glimmer/runtime/index.ts
@@ -84,3 +84,6 @@ export { normalizeProperty } from './lib/dom/props';
 export { ElementBuilder, NewElementBuilder, ElementOperations, clientBuilder } from './lib/vm/element-builder';
 export { rehydrationBuilder, RehydrateBuilder } from './lib/vm/rehydrate-builder';
 export { default as Bounds, ConcreteBounds, Cursor } from './lib/bounds';
+export { default as InstructionListExecutor } from './lib/vm/instruction-list/executor';
+export { default as InstructionListEncoder } from './lib/vm/instruction-list/encoder';
+export { Context } from './lib/vm/gbox';

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
@@ -23,11 +23,6 @@ APPEND_OPCODES.add(Op.Text, (vm, { op1: text }) => {
   vm.elements().appendText(vm.constants.getString(text));
 });
 
-APPEND_OPCODES.add(Op.OpenElementWithOperations, (vm, { op1: tag }) => {
-  let tagName = vm.constants.getString(tag);
-  vm.elements().openElement(tagName);
-});
-
 APPEND_OPCODES.add(Op.Comment, (vm, { op1: text }) => {
   vm.elements().appendComment(vm.constants.getString(text));
 });

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
@@ -20,20 +20,20 @@ import { ComponentElementOperations } from './component';
 import { CheckReference, CheckArguments } from './-debug-strip';
 
 APPEND_OPCODES.add(Op.Text, (vm, { op1: text }) => {
-  vm.elements().appendText(vm.constants.getString(text));
+  vm.instructions.appendText(vm.constants.getString(text));
 });
 
 APPEND_OPCODES.add(Op.Comment, (vm, { op1: text }) => {
-  vm.elements().appendComment(vm.constants.getString(text));
+  vm.instructions.appendComment(vm.constants.getString(text));
 });
 
 APPEND_OPCODES.add(Op.OpenElement, (vm, { op1: tag }) => {
-  vm.elements().openElement(vm.constants.getString(tag));
+  vm.instructions.openElement(vm.constants.getString(tag));
 });
 
 APPEND_OPCODES.add(Op.OpenDynamicElement, vm => {
   let tagName = check(check(vm.stack.pop(), CheckReference).value(), CheckString);
-  vm.elements().openElement(tagName);
+  vm.instructions.openElement(tagName);
 });
 
 APPEND_OPCODES.add(Op.PushRemoteElement, vm => {
@@ -61,11 +61,11 @@ APPEND_OPCODES.add(Op.PushRemoteElement, vm => {
     vm.updateWith(new Assert(cache));
   }
 
-  vm.elements().pushRemoteElement(element, guid, nextSibling);
+  vm.instructions.pushRemoteElement(element, guid, nextSibling);
 });
 
 APPEND_OPCODES.add(Op.PopRemoteElement, vm => {
-  vm.elements().popRemoteElement();
+  vm.instructions.popRemoteElement();
 });
 
 APPEND_OPCODES.add(Op.FlushElement, vm => {

--- a/packages/@glimmer/runtime/lib/opcodes.ts
+++ b/packages/@glimmer/runtime/lib/opcodes.ts
@@ -122,6 +122,7 @@ export class AppendOpcodes {
     let operation = this.evaluateOpcode[type];
     assert(!opcode.isMachine, `BUG: Mismatch between operation.syscall (true) and opcode.isMachine (${opcode.isMachine}) for ${opcode.type}`);
     operation(vm, opcode);
+    vm.flushInstructions();
   }
 }
 

--- a/packages/@glimmer/runtime/lib/vm/instruction-list/encoder.ts
+++ b/packages/@glimmer/runtime/lib/vm/instruction-list/encoder.ts
@@ -1,0 +1,57 @@
+import { Simple, Option } from '@glimmer/interfaces';
+import { Context } from '../gbox';
+import { Instruction as I } from './executor';
+
+const BUF_SIZE = 2048;
+
+export default class InstructionListEncoder {
+  instructions = new Uint32Array(new ArrayBuffer(BUF_SIZE));
+  offset = 0;
+
+  constructor(public cx: Context) { }
+
+  encode(inst: I, op1?: any, op2?: any) {
+    const { instructions } = this;
+    if (this.offset + 3 >= instructions.length) {
+      this.grow();
+    }
+
+    const { cx } = this;
+    this.instructions[this.offset++] = inst;
+    this.instructions[this.offset++] = cx.encode(op1);
+    this.instructions[this.offset++] = cx.encode(op2);
+  }
+
+  grow() {
+    let previous = this.instructions;
+    this.instructions = new Uint32Array(new ArrayBuffer(previous.byteLength * 2));
+    this.instructions.set(previous);
+  }
+
+  appendText(text: string) {
+    this.encode(I.AppendText, text);
+  }
+
+  appendComment(text: string) {
+    this.encode(I.AppendComment, text);
+  }
+
+  openElement(tagName: string) {
+    this.encode(I.OpenElement, tagName);
+  }
+
+  pushRemoteElement(element: Simple.Element, guid: string, nextSibling: Option<Simple.Node>) {
+    this.encode(I.Push, nextSibling);
+    this.encode(I.PushRemoteElement, element, guid);
+  }
+
+  popRemoteElement() {
+    this.encode(I.PopRemoteElement);
+  }
+
+  finalize(): ArrayBuffer {
+    let offset = this.offset;
+    this.offset = 0;
+    return this.instructions.buffer.slice(0, offset * 4) as ArrayBuffer;
+  }
+}

--- a/packages/@glimmer/runtime/lib/vm/instruction-list/executor.ts
+++ b/packages/@glimmer/runtime/lib/vm/instruction-list/executor.ts
@@ -1,0 +1,55 @@
+import { ElementBuilder } from '../element-builder';
+import { Context } from '../gbox';
+
+export const enum Instruction {
+  Push,
+  AppendText,
+  AppendComment,
+  OpenElement,
+  PushRemoteElement,
+  PopRemoteElement
+}
+
+/**
+ * An InstructionList encodes a list of operations that can only be performed
+ * from JavaScript running on the main thread into a binary data structure.
+ * Other contexts (e.g. code running in WebAssembly or a Web Worker) can create
+ * this data structure locally, then transfer it to the main thread for
+ * execution, avoiding costly context switches.
+ */
+export default class InstructionListExecutor {
+  constructor(public elementBuilder: ElementBuilder, public cx: Context) { }
+
+  execute(buf: ArrayBuffer) {
+    const list = new Uint32Array(buf);
+    const { elementBuilder, cx } = this;
+    const stack: any[] = [];
+
+    for (let i = 0; i < list.length; i += 3) {
+      const inst = list[i];
+      const op1 = cx.decode(list[i+1]);
+      const op2 = cx.decode(list[i+2]);
+
+      switch (inst) {
+        case Instruction.Push:
+          stack.push(op1);
+          break;
+        case Instruction.AppendText:
+          elementBuilder.appendText(op1);
+          break;
+        case Instruction.AppendComment:
+          elementBuilder.appendComment(op1);
+          break;
+        case Instruction.OpenElement:
+          elementBuilder.openElement(op1);
+          break;
+        case Instruction.PushRemoteElement:
+          elementBuilder.pushRemoteElement(op1, op2, stack.pop());
+          break;
+        case Instruction.PopRemoteElement:
+          elementBuilder.popRemoteElement(op1, op2, stack.pop());
+          break;
+      }
+    }
+  }
+}

--- a/packages/@glimmer/runtime/test/instruction-list-test.ts
+++ b/packages/@glimmer/runtime/test/instruction-list-test.ts
@@ -1,0 +1,98 @@
+import { Simple, Option } from '@glimmer/interfaces';
+import { InstructionListExecutor, InstructionListEncoder, Context } from "..";
+
+let executor: InstructionListExecutor;
+let dom: DOMOperations;
+let cx: Context;
+let encoder: InstructionListEncoder;
+
+type DOMOperation = [string] | [string, any] | [string, any, any, any];
+
+class DOMOperations {
+  operations: DOMOperation[] = [];
+
+  appendText(text: string) {
+    this.operations.push(['appendText', text]);
+  }
+
+  appendComment(text: string) {
+    this.operations.push(['appendComment', text]);
+  }
+
+  openElement(tagName: string) {
+    this.operations.push(['openElement', tagName]);
+  }
+
+  pushRemoteElement(element: Simple.Element, guid: string, nextSibling: Option<Simple.Node>) {
+    this.operations.push(['pushRemoteElement', element, guid, nextSibling]);
+  }
+
+  popRemoteElement() {
+    this.operations.push(['popRemoteElement']);
+  }
+}
+
+QUnit.module("Instruction List - DOM", {
+  beforeEach() {
+    cx = new Context();
+    dom = new DOMOperations();
+    executor = new InstructionListExecutor(dom as any, cx);
+    encoder = new InstructionListEncoder(cx);
+  }
+});
+
+QUnit.test("AppendText", function(assert) {
+  encoder.appendText('hello world');
+  executor.execute(encoder.finalize());
+  assert.deepEqual(dom.operations, [['appendText', 'hello world']]);
+});
+
+QUnit.test("AppendComment", function(assert) {
+  encoder.appendComment('goodbye world');
+  executor.execute(encoder.finalize());
+  assert.deepEqual(dom.operations, [['appendComment', 'goodbye world']]);
+});
+
+QUnit.test("OpenElement", function(assert) {
+  encoder.openElement('span');
+  executor.execute(encoder.finalize());
+  assert.deepEqual(dom.operations, [['openElement', 'span']]);
+});
+
+QUnit.test("PushRemoteElement", function(assert) {
+  const element = { tagName: 'span' };
+  const nextSibling = { nodeType: 1 };
+  encoder.pushRemoteElement(element as any, 'the-guid', nextSibling as any);
+  executor.execute(encoder.finalize());
+
+  assert.deepEqual(dom.operations, [['pushRemoteElement', element, 'the-guid', nextSibling]]);
+  assert.strictEqual(dom.operations[0][1], element);
+  assert.strictEqual(dom.operations[0][3], nextSibling);
+});
+
+QUnit.test("PopRemoteElement", function(assert) {
+  encoder.popRemoteElement();
+  executor.execute(encoder.finalize());
+
+  assert.deepEqual(dom.operations, [['popRemoteElement']]);
+});
+
+QUnit.test("Multiple instructions", function(assert) {
+  const element = { tagName: 'span' };
+  const nextSibling = { nodeType: 1 };
+
+  encoder.openElement('span');
+  encoder.pushRemoteElement(element as any, 'the-guid', nextSibling as any);
+  encoder.appendText('hello world');
+
+  executor.execute(encoder.finalize());
+
+  assert.deepEqual(dom.operations, [
+    ['openElement', 'span'],
+    ['pushRemoteElement', element, 'the-guid', nextSibling],
+    ['appendText', 'hello world']
+  ]);
+
+  assert.strictEqual(dom.operations[1][1], element);
+  assert.strictEqual(dom.operations[1][3], nextSibling);
+});

--- a/packages/@glimmer/vm/lib/-debug-strip.ts
+++ b/packages/@glimmer/vm/lib/-debug-strip.ts
@@ -447,12 +447,6 @@ OPCODE_METADATA(Op.OpenElement, {
   operands: 1
 });
 
-OPCODE_METADATA(Op.OpenElementWithOperations, {
-  name: 'OpenElementWithOperations',
-  ops: [Str('tag')],
-  operands: 1
-});
-
 OPCODE_METADATA(Op.OpenDynamicElement, {
   name: 'OpenDynamicElement',
   stackChange: -1

--- a/packages/@glimmer/vm/lib/opcodes.ts
+++ b/packages/@glimmer/vm/lib/opcodes.ts
@@ -312,18 +312,6 @@ export const enum Op {
 
   /**
    * Operation:
-   *   Open a new Element named `tag` with special operations provided
-   *   on the stack.
-   * Format:
-   *   (OpenElementWithOperations tag:#string)
-   * Operand Stack:
-   *   ..., ElementOperations →
-   *   ...
-   */
-  OpenElementWithOperations,
-
-  /**
-   * Operation:
    *   Open a new Element with a name on the stack and with special
    *   operations provided on the stack.
    * Format:


### PR DESCRIPTION
To avoid the performance overhead of context switching between JavaScript and WebAssembly, it is ideal to perform as much work in the current context as possible before yielding back.

Unfortunately, the current implementation of opcodes assumes direct access to JavaScript objects, including our DOM building abstractions like ElementBuilder. This makes these opcodes difficult to port to WebAssembly without having them frequently cross the JS/wasm boundary.

This commit introduces an intermediate binary data structure, called an InstructionList, for encoding a list of operations that can only be performed in the main JavaScript thread. Rather than producing side effects immediately, opcodes add an instruction to the list of instructions for the main thread to execute.

Once the thread of execution returns to the JavaScript implementation of the Glimmer VM, it executes any pending instructions before resuming execution of opcodes.

The implementation is primarily made up of two classes: the InstructionListEncoder, which efficiently records instructions into an ArrayBuffer, and the InstructionListExecutor, which iterates over that ArrayBuffer and executes each instruction in turn.

This first spike only includes a few basic DOM-related operations, but this could generalize to many more types of operations, like invoking component lifecycle hooks, etc. As more and more opcodes are moved into WebAssembly, we should be able to drop the JavaScript implementation of the InstructionListEncoder altogether, keeping just the relatively compact InstructionListExecutor for actually dispatching instructions.