### PR TITLE
Move PushRemoteElement to Rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /dist
 /node_modules
 /target
+packages/@glimmer/low-level/rust/target/
 tmp
 
 npm-debug.log

--- a/packages/@glimmer/low-level/rust/src/gbox.rs
+++ b/packages/@glimmer/low-level/rust/src/gbox.rs
@@ -11,6 +11,10 @@ const TAG_CONSTANT: u32        = 0b111;
 
 const TAG_SIZE: usize = 3;
 const TAG_MASK: u32 = (1 << TAG_SIZE) - 1;
+
+const OBJECT_TAG_CONST_REFERENCE: u32 = 0b1000;
+const OBJECT_TAG_SIZE: usize = 1;
+
 const CONSTANT_TAG_SIZE: usize = 2;
 const CONSTANT_TAG_MASK: u32 = (1 << CONSTANT_TAG_SIZE) - 1;
 
@@ -119,7 +123,7 @@ impl GBox {
                     bits => panic!("invalid boolean or void tag: 0x{:x}", bits),
                 }
             }
-            TAG_ANY => Value::Other(self.bits >> TAG_SIZE),
+            TAG_ANY => Value::Other(self.bits >> TAG_SIZE >> OBJECT_TAG_SIZE),
             TAG_COMPONENT => Value::Component(self.bits >> TAG_SIZE),
             TAG_CONSTANT => {
                 let bits = self.bits >> TAG_SIZE;
@@ -133,5 +137,9 @@ impl GBox {
             }
             tag => panic!("invalid tag: 0b{:b}", tag),
         }
+    }
+
+    pub fn is_const(&self) -> bool {
+        (self.bits & OBJECT_TAG_CONST_REFERENCE) != 0
     }
 }

--- a/packages/@glimmer/low-level/rust/src/instructions.rs
+++ b/packages/@glimmer/low-level/rust/src/instructions.rs
@@ -14,6 +14,7 @@ const APPEND_COMMENT: u32 = 2;
 const OPEN_ELEMENT: u32 = 3;
 const PUSH_REMOTE_ELEMENT: u32 = 4;
 const POP_REMOTE_ELEMENT: u32 = 5;
+const UPDATE_WITH_REFERENCE: u32 = 6;
 
 impl Encoder {
     pub fn new() -> Encoder {
@@ -73,5 +74,9 @@ impl Encoder {
 
     pub fn pop_remote_element(&mut self) {
         self.encode(POP_REMOTE_ELEMENT, GBox::undefined(), GBox::undefined())
+    }
+
+    pub fn update_with_reference(&mut self, reference: GBox) {
+        self.encode(UPDATE_WITH_REFERENCE, reference, GBox::undefined())
     }
 }

--- a/packages/@glimmer/low-level/rust/src/vm.rs
+++ b/packages/@glimmer/low-level/rust/src/vm.rs
@@ -273,6 +273,22 @@ impl VM {
                 self.instructions.open_element(val);
             }
 
+            Op::PushRemoteElement => {
+                let element = self.stack.pop(1); // CheckReference
+                let next_sibling = self.stack.pop(1); // CheckReference
+                let guid = self.stack.pop(1); // CheckReference
+
+                if !element.is_const() {
+                    self.instructions.update_with_reference(element)
+                }
+
+                if !next_sibling.is_const() {
+                    self.instructions.update_with_reference(next_sibling)
+                }
+
+                self.instructions.push_remote_element(element, guid, next_sibling);
+            }
+
             Op::PopRemoteElement => {
                 self.instructions.pop_remote_element();
             }

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
@@ -1,20 +1,17 @@
 import {
-  Reference,
-  ReferenceCache,
   Revision,
   Tag,
   VersionedReference,
   isConst,
   isConstTag
 } from '@glimmer/reference';
-import { Opaque, Option } from '@glimmer/util';
-import { expectStackChange, check, CheckString, CheckElement, CheckNode, CheckOption, CheckInstanceof } from '@glimmer/debug';
+import { Opaque } from '@glimmer/util';
+import { expectStackChange, check, CheckString, CheckOption, CheckInstanceof } from '@glimmer/debug';
 import { Simple } from '@glimmer/interfaces';
 import { Op, Register } from '@glimmer/vm';
 import { Modifier, ModifierManager } from '../../modifier/interfaces';
 import { APPEND_OPCODES, UpdatingOpcode } from '../../opcodes';
 import { UpdatingVM } from '../../vm';
-import { Assert } from './vm';
 import { DynamicAttribute } from '../../vm/attributes/dynamic';
 import { ComponentElementOperations } from './component';
 import { CheckReference, CheckArguments } from './-debug-strip';
@@ -22,34 +19,6 @@ import { CheckReference, CheckArguments } from './-debug-strip';
 APPEND_OPCODES.add(Op.OpenDynamicElement, vm => {
   let tagName = check(check(vm.stack.pop(), CheckReference).value(), CheckString);
   vm.instructions.openElement(tagName);
-});
-
-APPEND_OPCODES.add(Op.PushRemoteElement, vm => {
-  let elementRef = check(vm.stack.pop(), CheckReference);
-  let nextSiblingRef = check(vm.stack.pop(), CheckReference);
-  let guidRef = check(vm.stack.pop(), CheckReference);
-
-  let element: Simple.Element;
-  let nextSibling: Option<Simple.Node>;
-  let guid = guidRef.value() as string;
-
-  if (isConst(elementRef)) {
-    element = check(elementRef.value(), CheckElement);
-  } else {
-    let cache = new ReferenceCache(elementRef as Reference<Simple.Element>);
-    element = check(cache.peek(), CheckElement);
-    vm.updateWith(new Assert(cache));
-  }
-
-  if (isConst(nextSiblingRef)) {
-    nextSibling = check(nextSiblingRef.value(), CheckOption(CheckNode));
-  } else {
-    let cache = new ReferenceCache(nextSiblingRef as Reference<Option<Simple.Node>>);
-    nextSibling = check(cache.peek(), CheckOption(CheckNode));
-    vm.updateWith(new Assert(cache));
-  }
-
-  vm.instructions.pushRemoteElement(element, guid, nextSibling);
 });
 
 APPEND_OPCODES.add(Op.FlushElement, vm => {

--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -159,7 +159,7 @@ export default class VM<TemplateMeta> implements PublicVM {
       }
     };
     let cx = this.cx = new Context(this);
-    this.executor = new InstructionListExecutor(elementStack, cx);
+    this.executor = new InstructionListExecutor(this, elementStack, cx);
     this.wasmVM = WasmLowLevelVM.new(
       this.heap._wasmHeap(),
       APPEND_OPCODES,

--- a/packages/@glimmer/runtime/lib/vm/instruction-list/encoder.ts
+++ b/packages/@glimmer/runtime/lib/vm/instruction-list/encoder.ts
@@ -1,4 +1,3 @@
-import { Simple, Option } from '@glimmer/interfaces';
 import { Context } from '../gbox';
 import { Instruction as I } from './executor';
 import { WasmLowLevelVM } from '@glimmer/low-level';
@@ -13,10 +12,5 @@ export default class InstructionListEncoder {
 
   openElement(tagName: string) {
     this.encode(I.OpenElement, tagName);
-  }
-
-  pushRemoteElement(element: Simple.Element, guid: string, nextSibling: Option<Simple.Node>) {
-    this.encode(I.Push, nextSibling);
-    this.encode(I.PushRemoteElement, element, guid);
   }
 }

--- a/packages/@glimmer/runtime/test/gbox-test.ts
+++ b/packages/@glimmer/runtime/test/gbox-test.ts
@@ -1,4 +1,5 @@
-import { Context } from '..';
+import { Context, PrimitiveReference } from '..';
+import { ConstReference } from "@glimmer/reference";
 
 let ctx: Context;
 
@@ -38,4 +39,36 @@ QUnit.test("serializes strings", assert => {
 QUnit.test("serializes JavaScript objects", assert => {
   let person = { firstName: "Alex", lastName: "Crichton" };
   assert.strictEqual(ctx.decode(ctx.encode(person)), person);
+});
+
+QUnit.test("identifies ConstReference objects", assert => {
+  let ref = new ConstReference(true);
+  let gbox = ctx.encode(ref);
+  assert.strictEqual(ctx.decode(gbox), ref);
+  assert.ok(ctx.isConstReference(gbox), "isConstReference should be true");
+
+  let nonRef = {};
+  gbox = ctx.encode(nonRef);
+  assert.strictEqual(ctx.decode(gbox), nonRef);
+  assert.notOk(ctx.isConstReference(gbox), "isConstReference should be false");
+});
+
+QUnit.test("identifies PrimitiveReference objects", assert => {
+  let ref: PrimitiveReference<any> = PrimitiveReference.create(undefined);
+  assert.ok(ctx.isConstReference(ctx.encode(ref)));
+
+  ref = PrimitiveReference.create(null);
+  assert.ok(ctx.isConstReference(ctx.encode(ref)));
+
+  ref = PrimitiveReference.create(true);
+  assert.ok(ctx.isConstReference(ctx.encode(ref)));
+
+  ref = PrimitiveReference.create(false);
+  assert.ok(ctx.isConstReference(ctx.encode(ref)));
+
+  ref = PrimitiveReference.create(12345);
+  assert.ok(ctx.isConstReference(ctx.encode(ref)));
+
+  ref = PrimitiveReference.create("FooBarBaz");
+  assert.ok(ctx.isConstReference(ctx.encode(ref)));
 });

--- a/packages/@glimmer/runtime/test/gbox-test.ts
+++ b/packages/@glimmer/runtime/test/gbox-test.ts
@@ -1,0 +1,41 @@
+import { Context } from '..';
+
+let ctx: Context;
+
+QUnit.module("GBox", {
+  beforeEach() {
+    ctx = new Context({} as any);
+  }
+});
+
+QUnit.test("serializes numbers", assert => {
+  assert.strictEqual(ctx.decode(ctx.encode(0)), 0);
+  assert.strictEqual(ctx.decode(ctx.encode(1)), 1);
+  assert.strictEqual(ctx.decode(ctx.encode(9000)), 9000);
+  assert.strictEqual(ctx.decode(ctx.encode(-9000)), -9000);
+});
+
+QUnit.test("serializes booleans", assert => {
+  assert.strictEqual(ctx.decode(ctx.encode(true)), true);
+  assert.strictEqual(ctx.decode(ctx.encode(false)), false);
+});
+
+QUnit.test("serializes voids", assert => {
+  assert.strictEqual(ctx.decode(ctx.encode(null)), null);
+  assert.strictEqual(ctx.decode(ctx.encode(undefined)), undefined);
+});
+
+QUnit.test("serializes floats", assert => {
+  assert.strictEqual(ctx.decode(ctx.encode(1/3)), 1/3);
+  assert.strictEqual(ctx.decode(ctx.encode(999999999 / 66666666)), 999999999 / 66666666);
+  assert.strictEqual(ctx.decode(ctx.encode(-999999999 / 66666666)), -999999999 / 66666666);
+});
+
+QUnit.test("serializes strings", assert => {
+  assert.strictEqual(ctx.decode(ctx.encode("hello world")), "hello world");
+});
+
+QUnit.test("serializes JavaScript objects", assert => {
+  let person = { firstName: "Alex", lastName: "Crichton" };
+  assert.strictEqual(ctx.decode(ctx.encode(person)), person);
+});


### PR DESCRIPTION
To move PushRemoteElement into Rust, this PR primarily introduces two new abstractions.

1. To allow wasm to implement the existing logic around optimizing `ConstReference`s, we extend the GBox bitfield to add an additional bit for references that have a `CONSTANT_TAG` tag.
2. We add an `UpdateWithReference` instruction to `InstructionList` that takes a reference as the first op and generates a `ReferenceCache` as well as emitting an updating program opcode that asserts on the cached reference.