### PR TITLE
Move OpenDynamicElement, FlushElement and CloseElement into wasm

### DIFF
--- a/packages/@glimmer/low-level/rust/src/gbox.rs
+++ b/packages/@glimmer/low-level/rust/src/gbox.rs
@@ -34,6 +34,7 @@ pub struct GBox {
     bits: u32,
 }
 
+#[derive(PartialEq)]
 pub enum Value {
     Integer(i32),
     Null,

--- a/packages/@glimmer/low-level/rust/src/instructions.rs
+++ b/packages/@glimmer/low-level/rust/src/instructions.rs
@@ -12,9 +12,13 @@ const PUSH: u32 = 0;
 const APPEND_TEXT: u32 = 1;
 const APPEND_COMMENT: u32 = 2;
 const OPEN_ELEMENT: u32 = 3;
-const PUSH_REMOTE_ELEMENT: u32 = 4;
-const POP_REMOTE_ELEMENT: u32 = 5;
-const UPDATE_WITH_REFERENCE: u32 = 6;
+const OPEN_DYNAMIC_ELEMENT: u32 = 4;
+const FLUSH_ELEMENT_OPERATIONS: u32 = 5;
+const FLUSH_ELEMENT: u32 = 6;
+const PUSH_REMOTE_ELEMENT: u32 = 7;
+const POP_REMOTE_ELEMENT: u32 = 8;
+const CLOSE_ELEMENT: u32 = 9;
+const UPDATE_WITH_REFERENCE: u32 = 10;
 
 impl Encoder {
     pub fn new() -> Encoder {
@@ -62,6 +66,22 @@ impl Encoder {
 
     pub fn open_element(&mut self, tag_name: GBox) {
         self.encode(OPEN_ELEMENT, tag_name, GBox::undefined())
+    }
+
+    pub fn open_dynamic_element(&mut self, tag: GBox) {
+        self.encode(OPEN_DYNAMIC_ELEMENT, tag, GBox::undefined());
+    }
+
+    pub fn flush_element_operations(&mut self, operations: GBox) {
+        self.encode(FLUSH_ELEMENT_OPERATIONS, operations, GBox::undefined());
+    }
+
+    pub fn flush_element(&mut self) {
+        self.encode(FLUSH_ELEMENT, GBox::undefined(), GBox::undefined());
+    }
+
+    pub fn close_element(&mut self) {
+        self.encode(CLOSE_ELEMENT, GBox::undefined(), GBox::undefined());
     }
 
     pub fn push_remote_element(&mut self,

--- a/packages/@glimmer/low-level/rust/src/vm.rs
+++ b/packages/@glimmer/low-level/rust/src/vm.rs
@@ -273,6 +273,26 @@ impl VM {
                 self.instructions.open_element(val);
             }
 
+            Op::OpenDynamicElement => {
+                let tag = self.stack.pop(1);
+                self.instructions.open_dynamic_element(tag);
+            }
+
+            Op::FlushElement => {
+                let operations = self.register(T0);
+
+                if operations.value() != Value::Null {
+                    self.instructions.flush_element_operations(operations);
+                    self.set_register(T0, GBox::null())
+                }
+
+                self.instructions.flush_element();
+            }
+
+            Op::CloseElement => {
+                self.instructions.close_element();
+            }
+
             Op::PushRemoteElement => {
                 let element = self.stack.pop(1); // CheckReference
                 let next_sibling = self.stack.pop(1); // CheckReference

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
@@ -6,37 +6,14 @@ import {
   isConstTag
 } from '@glimmer/reference';
 import { Opaque } from '@glimmer/util';
-import { expectStackChange, check, CheckString, CheckOption, CheckInstanceof } from '@glimmer/debug';
+import { check } from '@glimmer/debug';
 import { Simple } from '@glimmer/interfaces';
-import { Op, Register } from '@glimmer/vm';
+import { Op } from '@glimmer/vm';
 import { Modifier, ModifierManager } from '../../modifier/interfaces';
 import { APPEND_OPCODES, UpdatingOpcode } from '../../opcodes';
 import { UpdatingVM } from '../../vm';
 import { DynamicAttribute } from '../../vm/attributes/dynamic';
-import { ComponentElementOperations } from './component';
 import { CheckReference, CheckArguments } from './-debug-strip';
-
-APPEND_OPCODES.add(Op.OpenDynamicElement, vm => {
-  let tagName = check(check(vm.stack.pop(), CheckReference).value(), CheckString);
-  vm.instructions.openElement(tagName);
-});
-
-APPEND_OPCODES.add(Op.FlushElement, vm => {
-  let operations = check(vm.fetchValue(Register.t0), CheckOption(CheckInstanceof(ComponentElementOperations)));
-
-  if (operations) {
-    operations.flush(vm);
-    vm.loadValue(Register.t0, null);
-  }
-
-  vm.elements().flushElement();
-});
-
-APPEND_OPCODES.add(Op.CloseElement, vm => {
-  vm.elements().closeElement();
-
-  expectStackChange(vm.stack, 0, 'CloseElement');
-});
 
 APPEND_OPCODES.add(Op.Modifier, (vm, { op1: handle }) => {
   let manager = vm.constants.resolveHandle<ModifierManager>(handle);

--- a/packages/@glimmer/runtime/lib/vm/instruction-list/executor.ts
+++ b/packages/@glimmer/runtime/lib/vm/instruction-list/executor.ts
@@ -1,17 +1,22 @@
 import { ReferenceCache, Reference } from "@glimmer/reference";
+import { Opaque } from "@glimmer/interfaces";
 import { ElementBuilder } from '../element-builder';
 import { Context } from '../gbox';
 import { VM } from '../../vm';
 import { Assert } from '../../compiled/opcodes/vm';
-import { Opaque } from "@glimmer/interfaces";
+import { ComponentElementOperations } from '../../compiled/opcodes/component';
 
 export const enum Instruction {
   Push,
   AppendText,
   AppendComment,
   OpenElement,
+  OpenDynamicElement,
+  FlushElementOperations,
+  FlushElement,
   PushRemoteElement,
   PopRemoteElement,
+  CloseElement,
   UpdateWithReference
 }
 
@@ -52,11 +57,23 @@ export default class InstructionListExecutor {
         case Instruction.OpenElement:
           elementBuilder.openElement(op1);
           break;
+        case Instruction.OpenDynamicElement:
+          elementBuilder.openElement(op1.value());
+          break;
         case Instruction.PushRemoteElement:
           elementBuilder.pushRemoteElement(op1.value(), op2.value(), stack.pop().value());
           break;
         case Instruction.PopRemoteElement:
           elementBuilder.popRemoteElement();
+          break;
+        case Instruction.FlushElementOperations:
+          (op1 as ComponentElementOperations).flush(vm);
+          break;
+        case Instruction.FlushElement:
+          elementBuilder.flushElement();
+          break;
+        case Instruction.CloseElement:
+          elementBuilder.closeElement();
           break;
         case Instruction.UpdateWithReference:
           updateWithReference(vm, op1);


### PR DESCRIPTION
This PR is pretty straightforward. I added `#[derive(PartialEq)]` to the `Value` enum. Is that correct?